### PR TITLE
docs: add mcq distractor rl guide

### DIFF
--- a/learn/README.md
+++ b/learn/README.md
@@ -1,0 +1,74 @@
+# Training LLM distractor generator with Verl
+
+This directory provides guidance for using [Verl](https://github.com/volcengine/verl) to train an LLM that produces high-quality distractors for multiple-choice questions (MCQs).
+
+## Overview
+1. **Generator LLM (agent)** – produces distractor options given a question stem and the correct answer.
+2. **Scoring LLM (environment reward)** – given the completed MCQ (stem, correct answer, generated distractors), it computes the probability of each option being correct. The reward is the Shannon entropy of this distribution, encouraging high uncertainty.
+3. **Algorithm** – use PPO (already implemented in Verl) to optimise the generator.
+
+The rest of this document outlines the steps to implement a custom dataset and reward function, and to run PPO training.
+
+## 1. Prepare the dataset
+Create a dataset returning `{"prompt": <stem>, "answer": <correct_answer>}` for each question.
+
+```python
+# learn/distractor_reward.py contains the full example
+class MCQDataset(torch.utils.data.Dataset):
+    def __init__(self, path: str):
+        self.samples = json.load(open(path))
+
+    def __len__(self):
+        return len(self.samples)
+
+    def __getitem__(self, idx):
+        item = self.samples[idx]
+        return {
+            "prompt": item["stem"],
+            "answer": item["answer"],
+        }
+```
+
+Reference this dataset from the config:
+
+```yaml
+# config snippet
+train_dataset:
+  path: learn/distractor_reward.py
+  name: MCQDataset
+  kwargs:
+    path: data/mcq_train.json
+```
+
+## 2. Implement the entropy-based reward
+`learn/distractor_reward.py` contains an example function `compute_entropy_reward` that:
+1. Assembles the full MCQ using the stem, correct answer and generated distractors.
+2. Queries a scoring LLM (served via [vLLM](https://github.com/vllm-project/vllm)) for the log-likelihood of each option.
+3. Converts log-likelihoods to a probability distribution and returns its Shannon entropy.
+
+In the Verl config, point to this function:
+
+```yaml
+custom_reward_function:
+  path: learn/distractor_reward.py
+  name: compute_entropy_reward
+  kwargs:
+    scoring_model: <model-name-or-endpoint>
+```
+
+## 3. Launch PPO training
+Use one of the example training scripts as a base (e.g. `examples/gemma/run_gemma.sh`) and override dataset and reward paths:
+
+```bash
+bash run_gemma.sh \
+  trainer.n_gpus_per_node=1 \
+  data.train_dataset.path=learn/distractor_reward.py \
+  data.custom_reward_function.path=learn/distractor_reward.py \
+  # plus usual PPO hyperparameters
+```
+
+Training will optimise the generator LLM to maximise entropy of the scoring model's answer distribution, yielding strong distractors.
+
+## 4. Extending
+You can incorporate additional signals, such as correctness checks or style constraints, by editing the reward function.
+

--- a/learn/distractor_reward.py
+++ b/learn/distractor_reward.py
@@ -1,0 +1,91 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example dataset and reward function for MCQ distractor generation.
+
+This module shows how to plug a custom dataset and reward into Verl. The
+`MCQDataset` yields question stems and correct answers. The
+`compute_entropy_reward` function queries a scoring model to compute the
+entropy of answer probabilities.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import torch
+from vllm import LLM, SamplingParams
+
+
+class MCQDataset(torch.utils.data.Dataset):
+    """Simple dataset for (stem, answer) pairs stored in JSON.
+
+    Each JSON entry must have keys ``stem`` and ``answer``.
+    """
+
+    def __init__(self, path: str) -> None:
+        self.samples: list[dict[str, str]] = json.load(open(path))
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.samples)
+
+    def __getitem__(self, idx: int) -> dict[str, str]:  # pragma: no cover - trivial
+        item = self.samples[idx]
+        return {"prompt": item["stem"], "answer": item["answer"]}
+
+
+def _score_options(model: LLM, prompt: str, options: list[str]) -> list[float]:
+    """Return log-likelihood of each option being the correct answer."""
+    sampling = SamplingParams(prompt_logprobs=True, max_tokens=0)
+    logps = []
+    for opt in options:
+        out = model.generate([prompt + opt], sampling)
+        # vLLM returns a list of logprobs per token
+        token_logps = out[0].prompt_logprobs
+        logp = sum(p for probs in token_logps for p in probs.values())
+        logps.append(logp)
+    return logps
+
+
+def compute_entropy_reward(
+    data_source: dict[str, str],
+    solution_str: str,
+    ground_truth: str,
+    extra_info=None,
+    scoring_model: str | None = None,
+) -> float:
+    """Reward: entropy of the scoring model's answer distribution.
+
+    Args:
+        data_source: contains ``prompt`` and ``distractors`` generated so far.
+        solution_str: the latest distractor produced by the agent.
+        ground_truth: the correct answer string.
+        scoring_model: model name or endpoint for vLLM.
+    """
+    options = data_source.get("distractors", []) + [solution_str]
+    prompt = data_source["prompt"]
+    correct = ground_truth
+    all_options = options + [correct]
+
+    llm = LLM(model=scoring_model) if scoring_model else LLM()  # pragma: no cover
+    logps = _score_options(llm, prompt, all_options)  # pragma: no cover
+
+    # Convert log-likelihoods to probabilities and compute Shannon entropy.
+    max_logp = max(logps)
+    probs = [math.exp(lp - max_logp) for lp in logps]
+    total = sum(probs)
+    probs = [p / total for p in probs]
+    entropy = -sum(p * math.log2(p) for p in probs if p > 0)
+    return entropy


### PR DESCRIPTION
## Summary
- add `learn` docs describing how to train a distractor-generating LLM with PPO and entropy-based rewards
- provide example dataset and reward function implementations

## Testing
- `pre-commit run --files learn/README.md learn/distractor_reward.py`
- `pytest tests/test_base_config_on_cpu.py tests/test_protocol_on_cpu.py` *(fails: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68a538af50bc832fbeb1bb90aa878900